### PR TITLE
fix(ci): trust the workspace so Gemini CLI workflows can run

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -200,6 +200,7 @@ jobs:
         id: 'run_gemini'
         uses: 'google-github-actions/run-gemini-cli@v0'
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           REPOSITORY: '${{ github.repository }}'
           USER_REQUEST: '${{ steps.get_context.outputs.user_request }}'

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -73,6 +73,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_issue_analysis'
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           ISSUE_TITLE: '${{ github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.issue.body }}'

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -83,6 +83,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_issue_analysis'
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'
           REPOSITORY: '${{ github.repository }}'

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -155,6 +155,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_pr_review'
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}'
           PR_DATA: '${{ steps.get_pr.outputs.pr_data || steps.get_pr_comment.outputs.pr_data }}'


### PR DESCRIPTION
## Problem

Every workflow in this repo that invokes `run-gemini-cli` is currently dead. The job fails in
under two seconds, before the CLI reads any input:

```
YOLO mode is enabled. All tool calls will be automatically approved.
Approval mode overridden to "default" because the current folder is not trusted.
Gemini CLI is not running in a trusted directory. To proceed, either use `--skip-trust`,
set the `GEMINI_CLI_TRUST_WORKSPACE=true` environment variable, or trust this directory
in interactive mode.
##[error]Process completed with exit code 1.
```

Recent Gemini CLI versions enforce a trusted-folders check that has no headless default. This
repo sets no `GEMINI_CLI_VERSION` variable, so it installs latest and trips the check on every
run. Observed on the `review-pr` job of run
[32181978154](https://github.com/kweinmeister/gemini-model-router/actions/runs/32181978154).

## Change

Add `GEMINI_CLI_TRUST_WORKSPACE: 'true'` to the `env:` block of the `run-gemini-cli` step in all
four workflows — one line each, no other changes:

| Workflow | Step |
|---|---|
| `gemini-pr-review.yml` | `Run Gemini PR Review` |
| `gemini-cli.yml` | `Run Gemini` |
| `gemini-issue-automated-triage.yml` | `Run Gemini Issue Analysis` |
| `gemini-issue-scheduled-triage.yml` | `Run Gemini Issue Analysis` |

This is the mechanism `google-github-actions/run-gemini-cli` documents for headless and
automated environments, and it matches the current upstream workflow templates.

## What this exposes

Workspace trust governs whether the CLI honors configuration it finds on disk — a `GEMINI.md`
or `.gemini/settings.json` in the checkout. That matters only where the checkout can contain
code written by someone outside the repo.

Two of the four check out contributor-authored code:

- `gemini-cli.yml:133` checks out `refs/pull/${N}/head`
- `gemini-pr-review.yml:79` checks out with no `ref:`, which on a `pull_request` event resolves
  to the merge ref

Both jobs are gated on the actor being `OWNER`, `MEMBER` or `COLLABORATOR`
(`gemini-cli.yml:17,43,56,66` and `gemini-pr-review.yml:46-74`), so neither is reachable from a
drive-by fork pull request. The workspace only ever holds code from someone who already has
write-adjacent trust on the repo.

The two triage workflows check out the default branch and never a contributor ref. Their
untrusted input is issue title and body, passed through `env:` — prompt-injection surface that
workspace trust does not govern in either direction, before or after this change.

## Verification

All five workflow files parse under `yaml.safe_load`, and the new key resolves into the correct
step's `env` in each:

```
gemini-cli.yml                       | gemini-cli     | trust = true
gemini-issue-automated-triage.yml    | triage-issue   | trust = true
gemini-issue-scheduled-triage.yml    | triage-issues  | trust = true
gemini-pr-review.yml                 | review-pr      | trust = true
```

End-to-end confirmation comes from this PR itself: `gemini-pr-review.yml` triggers on
`pull_request: opened`, so the review bot either posts a review here or it does not.

## Note

Separate from this, `#18` carries the Gemini model upgrade. The failed checks on that PR are
pinned to a superseded commit — its `CI / lint` failure was fixed by a follow-up `ruff.toml`
commit, and its review-bot failure is the bug this PR fixes.
