### PR TITLE
fix: call Vertex on the global endpoint so 3.x models resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The application is configured using environment variables. For both local develo
 
 ```sh
 export GOOGLE_CLOUD_PROJECT="your-gcp-project-id"
-export GOOGLE_CLOUD_LOCATION="us-central1"
+export GOOGLE_CLOUD_LOCATION="global"  # Vertex endpoint
+export REGION="us-central1"            # Cloud Run region
 export SERVICE_NAME="gemini-model-router"
 export DEBUG="False"  # Optional: Set to "True" for verbose logging
 ```
@@ -96,7 +97,7 @@ This project is designed for easy deployment to [Cloud Run](https://cloud.google
    ```sh
    gcloud run deploy "$SERVICE_NAME" \
      --source . \
-     --region="$GOOGLE_CLOUD_LOCATION" \
+     --region="$REGION" \
      --allow-unauthenticated \
      --labels="dev-tutorial=code-model-router" \
      --set-env-vars="GOOGLE_CLOUD_PROJECT=$GOOGLE_CLOUD_PROJECT" \

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ class GoogleLLM(BaseLLM):
         if cls._client is None:
             logger.info("Initializing singleton GenAI client...")
             project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
-            location = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+            location = os.getenv("GOOGLE_CLOUD_LOCATION", "global")
             if not project_id:
                 raise ValueError("GOOGLE_CLOUD_PROJECT environment variable not set.")
             cls._client = genai.Client(
@@ -96,8 +96,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     location = os.getenv("GOOGLE_CLOUD_LOCATION")
     if not location:
-        location = "us-central1"
-        logger.info("GOOGLE_CLOUD_LOCATION not set, defaulting to 'us-central1'.")
+        location = "global"
+        logger.info("GOOGLE_CLOUD_LOCATION not set, defaulting to 'global'.")
     os.environ["GOOGLE_LOCATION"] = location
 
     logger.info("Loading semantic router...")


### PR DESCRIPTION
## Problem

#18 moved all three routes to the Gemini 3.x line. The client still points at a regional Vertex
endpoint, which does not serve those models, so every routed request now returns 404:

```
Publisher model `projects/<project>/locations/us-central1/publishers/google/models/gemini-3.7-flash`
was not found or your project does not have access to it.
```

This affects all three tiers, so the router is non-functional in deployment regardless of which
route an utterance lands on.

Probed directly against a real project:

| endpoint | `gemini-3.5-flash-lite` | `gemini-3.1-pro-preview` | `gemini-3.7-flash` |
|---|---|---|---|
| `global` | ok | ok | ok |
| `us-central1` | 404 | 404 | 404 |

Gemini 2.5 models still answer in `us-central1`, which is why this default was correct until #18
and silently wrong afterwards.

## Change

**`main.py`** — default `GOOGLE_CLOUD_LOCATION` to `global` in both places that resolve it:
`RouteLayer.get_client` (the singleton the routes actually call) and the startup path that
exports `GOOGLE_LOCATION`. The environment variable still wins when set.

**`README.md`** — one variable was doing two incompatible jobs. `GOOGLE_CLOUD_LOCATION` fed both
`gcloud run deploy --region` and the Vertex client location:

```sh
--region="$GOOGLE_CLOUD_LOCATION" \
--set-env-vars="GOOGLE_CLOUD_LOCATION=$GOOGLE_CLOUD_LOCATION"
```

Those can no longer share a value. Cloud Run requires a real region and rejects `global`; Vertex
3.x requires `global` and 404s on a region. Whichever value you pick, one of the two breaks. Add
a separate `REGION` for the deploy target and leave `GOOGLE_CLOUD_LOCATION` for Vertex.

## Verification

`12 passed`, `ruff check` clean. No `us-central1` references remain outside the new `REGION`
line in the README.

The endpoint table above is live output against this project, not documentation.

## Related

Same defect in three sibling repos that also moved to 3.x while defaulting to a regional
endpoint — `ai-detector-data` (#50), `narrative-analyzer`, `ai-detector-app`.
`cosmic-guestbook`, `ai-appraiser` and `youtube-dashboard` already default to `global`.
