### PR TITLE
fix: merge duplicate updates key and group dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-updates:
+    groups:
+      python-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Fixes a duplicate top-level `updates:` key in dependabot.yml — YAML keeps only the last one, so the `pip` ecosystem entry was silently inactive and pip dependencies were never actually being updated.
- Groups minor/patch bumps within each ecosystem (pip, github-actions) into a single PR instead of one per package. Major version bumps still open their own PR for individual review.

Found while auditing GitHub Actions minutes usage across repos, but the duplicate-key bug is a correctness fix independent of that.

## Test plan
- [ ] Confirm Dependabot now opens pip PRs (previously silent)
- [ ] Confirm grouped PRs on the next scheduled run